### PR TITLE
Add role_based_accept_all sub status

### DIFF
--- a/src/zerobouncesdk/zb_validate_response.py
+++ b/src/zerobouncesdk/zb_validate_response.py
@@ -18,7 +18,8 @@ class ZBValidateResponse(ZBResponse):
     mail_server_did_not_respond, timeout_exceeded, failed_smtp_connection, mailbox_quota_exceeded,
     exception_occurred, possible_trap, role_based, global_suppression, mailbox_not_found, no_dns_entries,
     failed_syntax_check, possible_typo, unroutable_ip_address, leading_period_removed, does_not_accept_mail,
-    alias_address, role_based_catch_all, disposable, toxic, alternate, mx_forward, blocked, allowed, accept_all]"""
+    alias_address, role_based_catch_all, disposable, toxic, alternate, mx_forward, blocked, allowed, accept_all,
+    role_based_accept_all]"""
 
     account: str = None
     """The portion of the email address before the "@" symbol."""

--- a/src/zerobouncesdk/zb_validate_sub_status.py
+++ b/src/zerobouncesdk/zb_validate_sub_status.py
@@ -33,3 +33,4 @@ class ZBValidateSubStatus(Enum):
     blocked = "blocked"
     allowed = "allowed"
     accept_all = "accept_all"
+    role_based_accept_all = "role_based_accept_all"

--- a/tests/zero_bounce_test_case.py
+++ b/tests/zero_bounce_test_case.py
@@ -95,6 +95,17 @@ class ZeroBounceTestCase(BaseTestCase):
         self.assertEqual(response.status, ZBValidateStatus.catch_all)
         self.assertEqual(response.sub_status, ZBValidateSubStatus.accept_all)
 
+    def test_response_sub_status_role_based_accept_all(self):
+        self.requests_mock.get.return_value = MockResponse({
+            "address": "none@example.com",
+            "status": "valid",
+            "sub_status": "role_based_accept_all",
+        })
+        response = self.zero_bounce_client.validate("none@example.com")
+        self.assertEqual(response.address, "none@example.com")
+        self.assertEqual(response.status, ZBValidateStatus.valid)
+        self.assertEqual(response.sub_status, ZBValidateSubStatus.role_based_accept_all)
+
     def test_response_contains_errors(self):
         self.requests_mock.post.return_value = MockResponse({
             "email_batch": [],


### PR DESCRIPTION
Add `role_based_accept_all` sub status in ZBValidateSubStatus class.

As per new definition available in docs: [Status codes](https://www.zerobounce.net/docs/email-validation-api-quickstart/#status_codes__v2__)